### PR TITLE
adding a CNAME so github knows which project to serve

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-cohort16.com
+www.cohort16.com


### PR DESCRIPTION
## Status
**READY/IN DEVELOPMENT**

## Description
Based on http://stackoverflow.com/questions/9082499/custom-domain-for-github-project-pages I think we need a CNAME file since we have a project page within an organization so Github knows which project to serve after pointing the domain to the organization 

## Impacted Files in Application
Shouldn't affect other files

## Deploy Notes
Here is the current zone file for `cohort16.com`. The first line redirects cohort16.com to www.cohort16.com. The second line points www.cohort16.com to the content served at nss-day-cohort-16.github.io, which currently isn't anything since that's the organization subdomain. I expect the added CNAME file in this project will alert Github of where the content is to be served.

```
* 10800 IN CNAME webredir.vip.gandi.net.
www 10800 IN CNAME nss-day-cohort-16.github.io.
```

The custom domain in Github is set to `www.cohort16.com`. If this doesn't work, we can try a different method for deploying if it doesn't propagate within a few hours.